### PR TITLE
viimd - Updating quickstart DAG for AF3

### DIFF
--- a/learning-airflow/dags/example_astronauts.py
+++ b/learning-airflow/dags/example_astronauts.py
@@ -34,7 +34,7 @@ first DAG tutorial: https://docs.astronomer.io/learn/get-started-with-airflow
 ![Picture of the ISS](https://www.esa.int/var/esa/storage/images/esa_multimedia/images/2010/02/space_station_over_earth/10293696-3-eng-GB/Space_Station_over_Earth_card_full.jpg)
 """
 
-from airflow import Dataset
+from airflow.sdk import Asset
 from airflow.decorators import (
     dag,
     task,
@@ -102,7 +102,11 @@ def example_astronauts():
     # encapsulated in a list, as an argument to the task's `outlets` parameter.
     # For more guidance, see: https://www.astronomer.io/docs/learn/airflow-datasets
     
-    @task
+    #Define the Asset
+
+    @task(
+        outlets=[Asset(_DUCKDB_TABLE_NAME)]
+    )
     def get_astronaut_names(**context) -> list[dict]:
         """
         This task uses the requests library to retrieve a list of Astronauts

--- a/learning-airflow/dags/example_extract_astronauts.py
+++ b/learning-airflow/dags/example_extract_astronauts.py
@@ -1,17 +1,4 @@
-"""
-## Astronaut Extract Example DAG
-
-This DAG extracts data from the database table created and loaded
-by the `example_astronauts` DAG.
-
-The `get_astronauts_from_table` task executes a SQL query on the
-DuckDB database and prints out the data.
-
-The DAG can be easily modified to use the Airflow Datasets feature 
-so it is scheduled to run only when another DAG in the same Airflow 
-environment updates the table this DAG queries.
-"""
-
+from airflow.sdk import Asset
 from airflow.decorators import (
     dag,
     task,
@@ -35,29 +22,9 @@ _DUCKDB_TABLE_URI = f"duckdb://{_DUCKDB_INSTANCE_NAME}/{_DUCKDB_TABLE_NAME}"
 # Instantiate a DAG with the @dag decorator and set DAG parameters 
 # (see: https://www.astronomer.io/docs/learn/airflow-dag-parameters).
 
-# --------------------------------------- #
-# Exercise 3: Schedule a DAG on a Dataset #
-# --------------------------------------- #
-# Now that you have defined the `get_astronauts` task in the 
-# `example_astronauts` DAG as a Dataset producer (in Exercise 1), that 
-# Dataset can be used to schedule downstream DAG runs.
-#
-# Datasets can function like an API to communicate when data at a 
-# specific location in your ecosystem is ready for use. Datasets also 
-# reduce the code required to create cross-DAG dependencies. For example, 
-# it's very easy to schedule a DAG to run when a Dataset has been updated 
-# by another DAG in the same Airflow environment.
-# 
-# To schedule this DAG to run when `example_astronauts` updates the 
-# `current_astronauts` Dataset, add an import statement above to make the 
-# Airflow Dataset package available and set the schedule below using the 
-# `current_astronauts` Dataset. For a code example and more guidance on 
-# using Airflow Datasets, see: 
-# https://www.astronomer.io/docs/learn/airflow-datasets#dataset-definition.
-
 @dag(
     start_date=datetime(2024, 1, 1),  # date after which the DAG can be scheduled
-    schedule=None,  # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
+    schedule=[Asset(_DUCKDB_TABLE_NAME)],  # see: https://www.astronomer.io/docs/learn/scheduling-in-airflow for options
     catchup=False,  # see: https://www.astronomer.io/docs/learn/rerunning-dags#catchup
     max_consecutive_failed_dag_runs=5,  # auto-pauses the DAG after 5 consecutive failed runs, experimental
     doc_md=__doc__,  # add DAG Docs in the UI, see https://www.astronomer.io/docs/learn/custom-airflow-ui-docs-tutorial


### PR DESCRIPTION
This PR updates 2 of the Quickstart DAG's to use Asset instead of Dataset as per updates in AF3. 